### PR TITLE
manager: set phase to running before clearing inhibitors

### DIFF
--- a/gnome-session/gsm-manager.c
+++ b/gnome-session/gsm-manager.c
@@ -1071,6 +1071,11 @@ cancel_end_session (GsmManager *manager)
 
         g_cancellable_cancel (manager->priv->end_session_cancellable);
 
+        gsm_manager_set_phase (manager, GSM_MANAGER_PHASE_RUNNING);
+        manager->priv->logout_mode = GSM_MANAGER_LOGOUT_MODE_NORMAL;
+
+        manager->priv->logout_type = GSM_MANAGER_LOGOUT_NONE;
+
         /* clear all JIT inhibitors */
         gsm_store_foreach_remove (manager->priv->inhibitors,
                                   (GsmStoreFunc)inhibitor_is_jit,
@@ -1079,11 +1084,6 @@ cancel_end_session (GsmManager *manager)
         gsm_store_foreach (manager->priv->clients,
                            (GsmStoreFunc)_client_cancel_end_session,
                            NULL);
-
-        gsm_manager_set_phase (manager, GSM_MANAGER_PHASE_RUNNING);
-        manager->priv->logout_mode = GSM_MANAGER_LOGOUT_MODE_NORMAL;
-
-        manager->priv->logout_type = GSM_MANAGER_LOGOUT_NONE;
 
         start_phase (manager);
 }


### PR DESCRIPTION
e83da6fb3c9307895226ae4812ac27b782a57600 introduced a regression where
clicking cancel on the power off dialog causes the dialog to reopen
itself in case any JIT inhibitor has been taken, since the inhibitors
are removed here and removing the inhibitor causing the dialog to reopen
to support functionality that was removed from gnome-shell three years
ago. To fix this, set the manager phase to running before removing the
inhibitors to ensure the power off dialog does not reopen.

https://bugzilla.gnome.org/show_bug.cgi?id=728151

https://phabricator.endlessm.com/T12760
