### PR TITLE
Install one session definition only, for "GNOME"

### DIFF
--- a/debian/gnome-session.install
+++ b/debian/gnome-session.install
@@ -1,3 +1,3 @@
 usr/share/doc
-usr/share/xsessions/*.desktop
-usr/share/gnome-session/sessions/*.session
+usr/share/xsessions/gnome.desktop
+usr/share/gnome-session/sessions/gnome.session


### PR DESCRIPTION
In the past we used to provide our custom session definitions via
the eos-shell package, but since EOS 3.2 we moved to simply using
the definitions shipped by upstream and the change here to prevent
installing other files than the only one we need (i.e. for the
GNOME session) never got applied.

As a side effect, this meant that a second entry "GNOME on Xorg"
is now shown in GDM's session selector, which is very confusing to
our users, so let's only package the one we need here again.

https://phabricator.endlessm.com/T19780